### PR TITLE
Fix GitHub Pages vs local: duplicate Blog nav + Jekyll 4 deploy

### DIFF
--- a/.github/workflows/jekyll-pages.yml
+++ b/.github/workflows/jekyll-pages.yml
@@ -1,0 +1,43 @@
+# Build with Gemfile (Jekyll 4 + dart Sass) so production matches local dev.
+# Classic "Deploy from branch" on github.io still uses Jekyll 3.x, which diverges.
+name: Deploy site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - run: bundle exec jekyll build --trace
+        env:
+          JEKYLL_ENV: production
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,15 @@ social:
 # Theme (GitHub Pages compatible)
 theme: minima
 
+# Nav links (explicit paths). GitHub Pages still builds with Jekyll 3.x; jekyll-paginate
+# registers page 2+ as separate Page objects with distinct paths, so auto-discovered
+# header pages list duplicates "Blog". Local Jekyll 4 often reports the same path for
+# all paginated siblings, which hides the bug. Listing pages here matches Minima's
+# recommended approach and works on both builders.
+header_pages:
+  - about.md
+  - blog/index.html
+
 # Exclude from processing
 exclude:
   - Gemfile

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="site-header" role="banner">
 
   <div class="wrapper site-header__inner">
-    {%- comment -%} jekyll-paginate reuses the same source path for /blog/page2/, etc.; uniq keeps one nav entry. {%- endcomment -%}
+    {%- comment -%} Prefer site.header_pages (see _config.yml): Jekyll 3 on GitHub Pages gives paginated pages distinct paths, so path|uniq still yields multiple "Blog" links. {%- endcomment -%}
     {%- assign default_paths = site.pages | map: "path" | uniq -%}
     {%- assign page_paths = site.header_pages | default: default_paths | uniq -%}
     <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>


### PR DESCRIPTION
## Summary
Production used GitHub Pages’ legacy **Jekyll 3** builder while local dev uses **Jekyll 4** from the Gemfile. That caused:
- **Duplicate “Blog”** in the navbar (`/blog/` and `/blog/page2/`) because pagination exposes different `path` values under Jekyll 3, so `path | uniq` does not collapse them (unlike Jekyll 4 locally).
- **Different styling** from the older Sass/Jekyll stack.

## Changes
- **Explicit `header_pages`** in `_config.yml` (`about.md`, `blog/index.html`) so the nav does not auto-include paginated siblings (works on both builders).
- **GitHub Actions workflow** to `bundle exec jekyll build` and deploy `_site` via Pages Actions so prod matches local.

## After merge
In **Settings → Pages**, set the **Pages source** to **GitHub Actions** so the workflow replaces the legacy Jekyll 3 build.