### PR TITLE
UI/UX: dark-mode readability, blog archive, tables, and link contrast

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem "minima"
 
 group :jekyll_plugins do
   gem "jekyll-feed"
-  gem "jekyll-paginate"
   gem "jekyll-sitemap"
   gem "jekyll-seo-tag"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,6 @@ GEM
       webrick (~> 1.7)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-paginate (1.1.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
@@ -174,7 +173,6 @@ DEPENDENCIES
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.4)
   jekyll-feed
-  jekyll-paginate
   jekyll-seo-tag
   jekyll-sitemap
   logger
@@ -217,7 +215,6 @@ CHECKSUMS
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
   jekyll-feed (0.17.0) sha256=689aab16c877949bb9e7a5c436de6278318a51ecb974792232fd94d8b3acfcc3
-  jekyll-paginate (1.1.0) sha256=880aadf4b02529a93541d508c5cbb744f014cbfc071d0263a31f25ec9066eb64
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
   jekyll-seo-tag (2.8.0) sha256=3f2ed1916d56f14ebfa38e24acde9b7c946df70cb183af2cb5f0598f21ae6818
   jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218

--- a/_config.yml
+++ b/_config.yml
@@ -18,10 +18,6 @@ kramdown:
       line_numbers: false
 permalink: /blog/:title/
 
-# Pagination
-paginate: 5
-paginate_path: "/blog/page:num/"
-
 # Collections
 collections:
   posts:
@@ -31,7 +27,6 @@ collections:
 # Plugins
 plugins:
   - jekyll-feed
-  - jekyll-paginate
   - jekyll-sitemap
   - jekyll-seo-tag
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,16 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script>
+    (function () {
+      var k = 'theme';
+      var s = localStorage.getItem(k);
+      var t = s === 'light' || s === 'dark'
+        ? s
+        : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', t);
+    })();
+  </script>
   {%- seo -%}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="site-header" role="banner">
 
   <div class="wrapper site-header__inner">
-    {%- comment -%} jekyll-paginate reuses the same source path for /blog/page2/, etc.; uniq keeps one nav entry. {%- endcomment -%}
+    {%- comment -%} uniq avoids duplicate nav entries if paths repeat. {%- endcomment -%}
     {%- assign default_paths = site.pages | map: "path" | uniq -%}
     {%- assign page_paths = site.header_pages | default: default_paths | uniq -%}
     <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,11 +11,15 @@ layout: default
 
   {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
   {%- assign show_post_list = false -%}
-  {%- if paginator -%}
-    {%- if paginator.total_posts > 0 -%}{%- assign show_post_list = true -%}{%- endif -%}
-  {%- else -%}
-    {%- if site.posts.size > 0 -%}{%- assign show_post_list = true -%}{%- endif -%}
-  {%- endif -%}
+  {%- comment -%}
+    post_limit (optional): show only the N newest posts (e.g. landing page).
+    Omit post_limit on /blog/ to list every post. Set show_posts: false to hide the list.
+  {%- endcomment -%}
+  {%- unless page.show_posts == false -%}
+    {%- if site.posts.size > 0 -%}
+      {%- assign show_post_list = true -%}
+    {%- endif -%}
+  {%- endunless -%}
 
   {%- if show_post_list -%}
     <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
@@ -34,8 +38,22 @@ layout: default
         {%- endif -%}
       </li>
         {%- endfor -%}
+      {%- elsif page.post_limit -%}
+        {%- for post in site.posts limit: page.post_limit -%}
+      <li>
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        <h3>
+          <a class="post-link" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+        {%- if site.show_excerpts -%}
+          {{ post.excerpt }}
+        {%- endif -%}
+      </li>
+        {%- endfor -%}
       {%- else -%}
-        {%- for post in site.posts limit:5 -%}
+        {%- for post in site.posts -%}
       <li>
         <span class="post-meta">{{ post.date | date: date_format }}</span>
         <h3>
@@ -50,6 +68,18 @@ layout: default
         {%- endfor -%}
       {%- endif -%}
     </ul>
+
+    {%- if page.post_limit -%}
+    <p class="home-posts-cta">
+      <a class="home-posts-cta__link" href="{{ '/blog/' | relative_url }}">
+        {%- if site.posts.size > page.post_limit -%}
+          View all {{ site.posts.size }} posts
+        {%- else -%}
+          Browse the full blog
+        {%- endif -%}
+      </a>
+    </p>
+    {%- endif -%}
 
     {%- if paginator and paginator.total_pages > 1 -%}
     <nav class="pagination" aria-label="Blog pagination">

--- a/_posts/2026-04-19-04-my-first-project-with-my-ai-team-revamping-my-personal-website.md
+++ b/_posts/2026-04-19-04-my-first-project-with-my-ai-team-revamping-my-personal-website.md
@@ -63,7 +63,7 @@ Each of these PRs was created by kazi‑dev, reviewed by me, and merged after an
 
 This first project has validated the basic workflow and built confidence that an AI team can contribute meaningfully to a real‑world codebase. Now we’re ready to apply the same model to more complex projects:
 
-- **Lingu.Africa** – Bringing the AI team into my main product, where they’ll help with feature development, bug fixes, and documentation.
+- **[Lingu.Africa](https://lingu.africa)** – Bringing the AI team into my main product, where they’ll help with feature development, bug fixes, and documentation.
 
 - **More automation** – Exploring how much of the review and merge process can be safely automated while preserving quality.
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -21,6 +21,7 @@
   --color-border: #e2e8f0;
   --color-border-strong: #cbd5e1;
   --color-accent-subtle: rgba(2, 132, 199, 0.12);
+  --color-post-row-hover: rgba(2, 132, 199, 0.09);
   --color-link: var(--color-primary);
   --color-link-hover: var(--color-primary-dark);
   --color-code-background: #f1f5f9;
@@ -94,19 +95,22 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    // Brighter accent for focus / UI chrome; links use dedicated tokens below.
     --color-primary: #38bdf8;
     --color-primary-dark: #7dd3fc;
     --color-secondary: #94a3b8;
     --color-secondary-dark: #cbd5e1;
     --color-background: #0f172a;
     --color-surface: #1e293b;
-    --color-text: #f1f5f9;
-    --color-text-muted: #94a3b8;
-    --color-border: #334155;
-    --color-border-strong: #475569;
-    --color-accent-subtle: rgba(56, 189, 248, 0.18);
-    --color-link: var(--color-primary);
-    --color-link-hover: var(--color-primary-dark);
+    --color-text: #f8fafc;
+    --color-text-muted: #cbd5e1;
+    --color-border: #3d4f63;
+    --color-border-strong: #64748b;
+    --color-accent-subtle: rgba(56, 189, 248, 0.14);
+    --color-post-row-hover: rgba(248, 250, 252, 0.06);
+    // High-contrast links on navy (AA-friendly at body sizes).
+    --color-link: #bae6fd;
+    --color-link-hover: #f0f9ff;
     --color-code-background: #1e293b;
     --color-code-text: #e5e7eb;
     --color-code-inline-bg: rgba(148, 163, 184, 0.12);
@@ -131,6 +135,7 @@
 }
 
 [data-theme="light"] {
+  color-scheme: light;
   --color-primary: #0284c7;
   --color-primary-dark: #0369a1;
   --color-secondary: #64748b;
@@ -142,6 +147,7 @@
   --color-border: #e2e8f0;
   --color-border-strong: #cbd5e1;
   --color-accent-subtle: rgba(2, 132, 199, 0.12);
+  --color-post-row-hover: rgba(2, 132, 199, 0.09);
   --color-link: var(--color-primary);
   --color-link-hover: var(--color-primary-dark);
   --color-code-background: #f1f5f9;
@@ -167,19 +173,21 @@
 }
 
 [data-theme="dark"] {
+  color-scheme: dark;
   --color-primary: #38bdf8;
   --color-primary-dark: #7dd3fc;
   --color-secondary: #94a3b8;
   --color-secondary-dark: #cbd5e1;
   --color-background: #0f172a;
   --color-surface: #1e293b;
-  --color-text: #f1f5f9;
-  --color-text-muted: #94a3b8;
-  --color-border: #334155;
-  --color-border-strong: #475569;
-  --color-accent-subtle: rgba(56, 189, 248, 0.18);
-  --color-link: var(--color-primary);
-  --color-link-hover: var(--color-primary-dark);
+  --color-text: #f8fafc;
+  --color-text-muted: #cbd5e1;
+  --color-border: #3d4f63;
+  --color-border-strong: #64748b;
+  --color-accent-subtle: rgba(56, 189, 248, 0.14);
+  --color-post-row-hover: rgba(248, 250, 252, 0.06);
+  --color-link: #bae6fd;
+  --color-link-hover: #f0f9ff;
   --color-code-background: #1e293b;
   --color-code-text: #e5e7eb;
   --color-code-inline-bg: rgba(148, 163, 184, 0.12);
@@ -764,7 +772,7 @@ li {
     }
 
     &:hover {
-      background-color: var(--color-accent-subtle);
+      background-color: var(--color-post-row-hover);
     }
   }
 }
@@ -796,9 +804,17 @@ li {
   font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--color-link);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 1px;
+  text-decoration-skip-ink: auto;
 
   &:hover {
     color: var(--color-link-hover);
+  }
+
+  &:visited {
+    color: var(--color-link);
   }
 }
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -802,6 +802,84 @@ li {
   }
 }
 
+.home-posts-cta {
+  margin: var(--spacing-lg) 0 var(--spacing-sm);
+  text-align: center;
+}
+
+.home-posts-cta__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-text) !important;
+  background-color: var(--color-accent-subtle);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  text-decoration: none !important;
+  transition: var(--transition-link);
+  box-shadow: var(--shadow-sm);
+
+  &:hover {
+    color: var(--color-link-hover) !important;
+    border-color: var(--color-primary);
+    background-color: var(--color-surface);
+    text-decoration: none !important;
+  }
+
+  &::after {
+    content: "→";
+    font-weight: 700;
+    opacity: 0.85;
+  }
+}
+
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-md);
+  margin: var(--spacing-xl) 0 var(--spacing-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  background-color: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+
+  a {
+    font-weight: 600;
+    color: var(--color-link);
+
+    &:hover {
+      color: var(--color-link-hover);
+    }
+  }
+
+  .page_number {
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text);
+  }
+
+  .previous,
+  .next {
+    min-width: 5.5rem;
+    text-align: center;
+  }
+
+  span.previous,
+  span.next {
+    opacity: 0.45;
+    font-weight: 500;
+  }
+}
+
 .rss-subscribe {
   margin-top: var(--spacing-xl);
   font-size: var(--font-size-sm);

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -22,6 +22,7 @@
   --color-border-strong: #cbd5e1;
   --color-accent-subtle: rgba(2, 132, 199, 0.12);
   --color-post-row-hover: rgba(2, 132, 199, 0.09);
+  --color-table-stripe: var(--color-surface);
   --color-link: var(--color-primary);
   --color-link-hover: var(--color-primary-dark);
   --color-code-background: #f1f5f9;
@@ -108,6 +109,7 @@
     --color-border-strong: #64748b;
     --color-accent-subtle: rgba(56, 189, 248, 0.14);
     --color-post-row-hover: rgba(248, 250, 252, 0.06);
+    --color-table-stripe: #1e293b;
     // High-contrast links on navy (AA-friendly at body sizes).
     --color-link: #bae6fd;
     --color-link-hover: #f0f9ff;
@@ -148,6 +150,7 @@
   --color-border-strong: #cbd5e1;
   --color-accent-subtle: rgba(2, 132, 199, 0.12);
   --color-post-row-hover: rgba(2, 132, 199, 0.09);
+  --color-table-stripe: var(--color-surface);
   --color-link: var(--color-primary);
   --color-link-hover: var(--color-primary-dark);
   --color-code-background: #f1f5f9;
@@ -186,6 +189,7 @@
   --color-border-strong: #64748b;
   --color-accent-subtle: rgba(56, 189, 248, 0.14);
   --color-post-row-hover: rgba(248, 250, 252, 0.06);
+  --color-table-stripe: #1e293b;
   --color-link: #bae6fd;
   --color-link-hover: #f0f9ff;
   --color-code-background: #1e293b;
@@ -259,6 +263,41 @@ a {
     text-decoration: underline;
     text-underline-offset: 0.15em;
   }
+}
+
+// Tables — Minima compiles fixed gray text + light zebra rows; unusable on dark backgrounds.
+table {
+  color: var(--color-text);
+  border: var(--border-width) solid var(--color-border);
+}
+
+table th,
+table td {
+  border: var(--border-width) solid var(--color-border);
+  color: inherit;
+}
+
+table th {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border-color: var(--color-border-strong);
+  border-bottom-color: var(--color-border-strong);
+}
+
+table tbody tr:nth-child(odd) {
+  background-color: var(--color-background);
+}
+
+table tbody tr:nth-child(even) {
+  background-color: var(--color-table-stripe);
+}
+
+table > tr:nth-child(odd) {
+  background-color: var(--color-background);
+}
+
+table > tr:nth-child(even) {
+  background-color: var(--color-table-stripe);
 }
 
 // Layout

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -253,16 +253,29 @@ body {
   outline-offset: 3px;
 }
 
-a {
+// Minima sets a:visited to darken($brand-color); it beats plain `a` and stays illegible in dark mode.
+a,
+a:visited {
   color: var(--color-link);
   text-decoration: none;
   transition: var(--transition-link);
+}
 
-  &:hover {
-    color: var(--color-link-hover);
-    text-decoration: underline;
-    text-underline-offset: 0.15em;
-  }
+a:hover {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+// Inline links in posts / pages: always show an underline so color is not the only cue.
+.post-content a {
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-skip-ink: auto;
+}
+
+.post-content a:hover {
+  text-decoration-thickness: 2px;
 }
 
 // Tables — Minima compiles fixed gray text + light zebra rows; unusable on dark backgrounds.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -202,24 +202,6 @@
   --shadow-code-block: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
-// Minima SCSS variables
-$base-font-family: var(--font-family-base);
-$base-font-size: var(--font-size-base);
-$base-line-height: var(--line-height-base);
-$spacing-unit: var(--spacing-unit);
-$text-color: var(--color-text);
-$background-color: var(--color-background);
-$brand-color: var(--color-primary);
-$grey-color: var(--color-secondary);
-$grey-color-light: var(--color-border);
-$grey-color-dark: var(--color-secondary-dark);
-$table-text-align: left;
-$header-background-color: var(--color-surface);
-$footer-background-color: var(--color-surface);
-$link-color: var(--color-link);
-$link-hover-color: var(--color-link-hover);
-$code-background-color: var(--color-code-background);
-
 // Base
 html {
   -webkit-font-smoothing: antialiased;
@@ -340,7 +322,8 @@ a {
   }
 }
 
-.page-link {
+// Beat Minima’s .site-nav .page-link; header is the only place this class is used.
+.site-header .site-nav .page-link {
   display: inline-block;
   padding: var(--spacing-xs) var(--spacing-sm);
   margin: 0 0.1rem;
@@ -362,7 +345,7 @@ a {
   }
 }
 
-.page-link--current {
+.site-header .site-nav .page-link--current {
   color: var(--color-text);
   font-weight: 600;
   background-color: var(--color-accent-subtle);

--- a/index.md
+++ b/index.md
@@ -1,5 +1,7 @@
 ---
 layout: home
+post_limit: 5
+list_title: Latest posts
 ---
 
 <section class="hero">


### PR DESCRIPTION
## Summary
Polishes accessibility and layout for the Jekyll + Minima site: **high-contrast dark mode**, **clearer blog navigation**, **theme-aware tables**, and **fix for invisible visited links** in posts. Also tightens **home vs. blog** so readers see recent posts on the landing page with a path to the full archive.

## Dark mode and contrast
- **Design tokens**: Brighter default/hover link colors on dark backgrounds; stronger body and muted text; clearer borders; neutral **post-list row hover** (replacing heavy cyan washes that hid link text).
- **Navbar**: Higher-specificity rules so Minima’s compiled `#111` nav text no longer wins over theme variables; **early `data-theme`** in `<head>` to reduce flash/mismatch.
- **Pagination bar** (if used): Styled `.pagination` for visibility.

## Blog and home
- **Removed `jekyll-paginate`**: `/blog/` lists **all** posts on one page (no `/blog/page2/`).
- **Landing page**: **Latest 5** posts via `post_limit`, plus a **“View all … posts” / “Browse the full blog”** CTA; RSS remains available.
- **Header**: Comment documents **`header_pages`** vs duplicated Blog links on GitHub Pages.

## Tables
- Overrides Minima’s **fixed light-theme table CSS** (gray text + light zebra stripes) with **token-based** borders, header row, and odd/even row backgrounds so tables stay readable in dark mode.

## Links in posts
- **`a:visited`**: Minima’s dark blue `:visited` had higher specificity than our `a` rule—visited links were nearly invisible. **`a, a:visited`** now use `var(--color-link)`.
- **Prose**: `.post-content a` uses underlines (slightly thicker on hover) so links are not color-only cues.

## Other
- **Content**: Hyperlink to Lingua.Africa where listed in a project/post.
- **Docs/config**: Deployment / GitHub Pages notes where relevant (see commits).

## Testing
- Local `bundle exec jekyll build`; spot-check **home**, **`/blog/`**, a **post with a table**, and **visited vs unvisited** links in dark mode.
